### PR TITLE
Change `assert_cfg` args order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 matrix:
   include:
-    - rust: 1.15.0
+    - rust: 1.20.0
     - rust: stable
     - rust: stable
       os: osx

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,27 +65,30 @@ pub extern crate core as _core;
 ///
 /// # Examples
 ///
-/// A project may not support a set of configurations and thus you may want to
-/// report why:
+/// A project will simply fail to compile if the given configuration is not set.
 ///
 /// ```
-/// # #[macro_use]
-/// # extern crate static_assertions;
+/// # #[macro_use] extern crate static_assertions;
+/// # fn main() {}
+/// // We're not masochists
+/// # #[cfg(not(target_pointer_width = "16"))] // Just in case
+/// assert_cfg!(not(target_pointer_width = "16"));
+/// ```
+///
+/// If a project does not support a set of configurations, you may want to
+/// report why. There is the option of providing a compile error message string:
+///
+/// ```
+/// # #[macro_use] extern crate static_assertions;
+/// # fn main() {}
 /// # #[cfg(any(unix, linux))]
 /// assert_cfg!(any(unix, linux), "There is only support Unix or Linux");
-/// # fn main() {}
-/// ```
 ///
-/// If users need to specify a database back-end:
-///
-/// ```
-/// # #[macro_use]
-/// # extern crate static_assertions;
+/// // User needs to specify a database back-end
 /// # #[cfg(target_pointer_width = "0")] // Impossible
 /// assert_cfg!(all(not(all(feature = "mysql", feature = "mongodb")),
 ///                 any(    feature = "mysql", feature = "mongodb")),
 ///             "Must exclusively use MySQL or MongoDB as database back-end");
-/// # fn main() {}
 /// ```
 ///
 /// Some configurations are impossible. For example, we can't be compiling for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,8 @@ pub extern crate core as _core;
 /// # fn main() {}
 /// ```
 ///
-/// We can't be compiling for both Unix _and_ Windows simultaneously:
+/// Some configurations are impossible. For example, we can't be compiling for
+/// both Unix _and_ Windows simultaneously:
 ///
 /// ```compile_fail
 /// # #[macro_use] extern crate static_assertions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub extern crate core as _core;
 /// # #[macro_use] extern crate static_assertions;
 /// # fn main() {}
 /// # #[cfg(any(unix, linux))]
-/// assert_cfg!(any(unix, linux), "There is only support Unix or Linux");
+/// assert_cfg!(any(unix, linux), "There is only support for Unix or Linux");
 ///
 /// // User needs to specify a database back-end
 /// # #[cfg(target_pointer_width = "0")] // Impossible

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,9 +83,9 @@ pub extern crate core as _core;
 /// # #[macro_use]
 /// # extern crate static_assertions;
 /// # #[cfg(target_pointer_width = "0")] // Impossible
-/// assert_cfg!("Must exclusively use MySQL or MongoDB as database back-end",
-///             all(not(all(feature = "mysql", feature = "mongodb")),
-///                 any(    feature = "mysql", feature = "mongodb")));
+/// assert_cfg!(all(not(all(feature = "mysql", feature = "mongodb")),
+///                 any(    feature = "mysql", feature = "mongodb")),
+///             "Must exclusively use MySQL or MongoDB as database back-end");
 /// # fn main() {}
 /// ```
 ///
@@ -94,13 +94,13 @@ pub extern crate core as _core;
 /// ```compile_fail
 /// # #[macro_use] extern crate static_assertions;
 /// # fn main() {
-/// assert_cfg!("No, that's not how it works! ಠ_ಠ", all(unix, windows));
+/// assert_cfg!(all(unix, windows), "No, that's not how it works! ಠ_ಠ");
 /// # }
 /// ```
 #[macro_export]
 macro_rules! assert_cfg {
     () => {};
-    ($msg:expr, $($cfg:tt)*) => {
+    ($($cfg:meta)+, $msg:expr) => {
         #[cfg(not($($cfg)*))]
         compile_error!($msg);
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,8 @@ pub extern crate core as _core;
 /// ```
 /// # #[macro_use]
 /// # extern crate static_assertions;
-/// // We should only be compiling for Unix or Linux
 /// # #[cfg(any(unix, linux))]
-/// assert_cfg!(any(unix, linux));
+/// assert_cfg!(any(unix, linux), "There is only support Unix or Linux");
 /// # fn main() {}
 /// ```
 ///


### PR DESCRIPTION
Made the compile error message last, which is consistent with other assertion macros.

This is a breaking change and would require a `0.x` semver bump. Currently that means going from `0.2.x` to `0.3.0`.