### PR TITLE
Make assert_eq_type rely on a trait bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog] and this project adheres to
 [Semantic Versioning].
 
 ## [Unreleased]
+### Fixed
+- `assert_eq_type!` now works with types involving lifetimes.
 
 ## [0.3.3] - 2019-06-12
 ### Added


### PR DESCRIPTION
This makes `assert_eq_type` work with types involving lifetimes.