### PR TITLE
Add `assert_impl_one!` macro

### DIFF
--- a/src/assert_impl.rs
+++ b/src/assert_impl.rs
@@ -52,10 +52,16 @@
 macro_rules! assert_impl_one {
     ($type:ty: $t:path, $($ts:path),+ $(,)?) => {
         assert_impl_any!($type: $t, $($ts),+);
-        // FIXME: Only works against the first trait; needs to check all
-        // subsequent traits against one another.
-        $(assert_not_impl_all!($type: $t, $ts);)+
+        assert_impl_one!(_priv $type: $t, $($ts),+);
     };
+    // Expands into all combinations of trait pairs to ensure `$type` does not
+    // implement any pair of traits.
+    (_priv $type:ty: $t:path, $($ts:path),+) => {
+        $(assert_not_impl_all!($type: $t, $ts);)+
+        assert_impl_one!(_priv $type: $($ts),+);
+    };
+    // Finished passing along pairs, nothing to do.
+    (_priv $type:ty: $t:path) => {};
 }
 
 /// Asserts that the type implements _all_ of the given traits.

--- a/tests/trait_impl.rs
+++ b/tests/trait_impl.rs
@@ -20,3 +20,20 @@ assert_impl_all!(str: Send, Sync, AsRef<[u8]>,);
 assert_impl_any!((): Send, Sync);
 assert_impl_any!((): Send, From<u8>);
 assert_impl_any!((): From<u8>, From<u16>, Send);
+
+#[allow(dead_code)]
+struct Foo;
+
+trait A {}
+trait B {}
+trait C {}
+
+impl B for Foo {}
+
+assert_impl_one!(Foo: A, B);
+assert_impl_one!(Foo: B, A);
+assert_impl_one!(Foo: B, C);
+assert_impl_one!(Foo: C, B);
+assert_impl_one!(Foo: A, B, C);
+assert_impl_one!(Foo: B, C, A);
+assert_impl_one!(Foo: C, A, B);


### PR DESCRIPTION
This adds `assert_impl_one!`, which ensures that exactly **one** in a set of traits is implemented.

---

~This current implementation doesn't entirely work because traits after the first aren't checked against each other with `assert_not_impl_all!`.~

Thanks to @SimonSapin's [elegant solution](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=54fed9689b5ab32c5606b626d16bd5bf), this macro is made possible. Subsequent traits were previously only checked against the first and not to one another. A correct implementation requires checking `assert_not_impl_all!` against all trait pairs. Also, it turns out that the "Mutually Exclusive Trait Implementations" docs before also wasn't implemented correctly for this reason.