### PR TITLE
Improve `const_assert` error messages

### DIFF
--- a/src/const_assert.rs
+++ b/src/const_assert.rs
@@ -51,9 +51,7 @@
 #[macro_export]
 macro_rules! const_assert {
     ($x:expr $(,)?) => {
-        #[allow(unknown_lints, eq_op)]
         const _: fn() = ||{
-            const ASSERT: bool = $x;
             let _: $crate::True = $crate::to_bool!($x);
         };
     };

--- a/src/const_assert.rs
+++ b/src/const_assert.rs
@@ -52,32 +52,9 @@
 macro_rules! const_assert {
     ($x:expr $(,)?) => {
         #[allow(unknown_lints, eq_op)]
-        const _: () = {
-            #[derive(Copy, Clone)]
-            struct True;
-            #[derive(Copy, Clone)]
-            struct False;
-
-            trait ToBool {
-                type Value;
-                fn to_bool(_: Self) -> Self::Value;
-            }
-            impl ToBool for [(); 0] {
-                type Value = False;
-                fn to_bool(_: Self) -> Self::Value {
-                    False
-                }
-            }
-            impl ToBool for [(); 1] {
-                type Value = True;
-                fn to_bool(_: Self) -> Self::Value {
-                    True
-                }
-            }
-            fn const_assert() {
-                const ASSERT: bool = $x;
-                let _: True = ToBool::to_bool([(); ASSERT as usize]);
-            }
+        const _: fn() = ||{
+            const ASSERT: bool = $x;
+            let _: $crate::True = $crate::to_bool!($x);
         };
     };
 }

--- a/src/const_assert.rs
+++ b/src/const_assert.rs
@@ -52,7 +52,33 @@
 macro_rules! const_assert {
     ($x:expr $(,)?) => {
         #[allow(unknown_lints, eq_op)]
-        const _: [(); 0 - !{ const ASSERT: bool = $x; ASSERT } as usize] = [];
+        const _: () = {
+            #[derive(Copy, Clone)]
+            struct True;
+            #[derive(Copy, Clone)]
+            struct False;
+
+            trait ToBool {
+                type Value;
+                fn to_bool(_: Self) -> Self::Value;
+            }
+            impl ToBool for [(); 0] {
+                type Value = False;
+                fn to_bool(_: Self) -> Self::Value {
+                    False
+                }
+            }
+            impl ToBool for [(); 1] {
+                type Value = True;
+                fn to_bool(_: Self) -> Self::Value {
+                    True
+                }
+            }
+            fn const_assert() {
+                const ASSERT: bool = $x;
+                let _: True = ToBool::to_bool([(); ASSERT as usize]);
+            }
+        };
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,9 @@ pub use proc_static_assertions::assert;
 #[doc(hidden)]
 pub extern crate core as _core;
 
+#[doc(hidden)]
+pub use type_level_bool::{True, False};
+
 mod assert_cfg;
 mod assert_eq_align;
 mod assert_eq_size;
@@ -116,3 +119,5 @@ mod assert_obj_safe;
 mod assert_trait;
 mod assert_type;
 mod const_assert;
+#[doc(hidden)]
+pub mod type_level_bool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,5 +119,7 @@ mod assert_obj_safe;
 mod assert_trait;
 mod assert_type;
 mod const_assert;
+
+/// This module should never be used publicly and is not part of this crate's semver requirements.
 #[doc(hidden)]
 pub mod type_level_bool;

--- a/src/type_level_bool.rs
+++ b/src/type_level_bool.rs
@@ -1,0 +1,30 @@
+#[derive(Copy, Clone, Debug)]
+pub struct True;
+#[derive(Copy, Clone, Debug)]
+pub struct False;
+
+pub trait ToBool {
+    type Value;
+    fn to_bool(_: Self) -> Self::Value;
+}
+impl ToBool for [(); 0] {
+    type Value = False;
+    fn to_bool(_: Self) -> Self::Value {
+        False
+    }
+}
+impl ToBool for [(); 1] {
+    type Value = True;
+    fn to_bool(_: Self) -> Self::Value {
+        True
+    }
+}
+
+/// Converts a `const bool` to a type-level boolean.
+#[macro_export]
+macro_rules! to_bool {
+    ($x:expr $(,)?) => {{
+        const ASSERT: bool = $x;
+        $crate::type_level_bool::ToBool::to_bool([(); ASSERT as usize])
+    }};
+}

--- a/src/type_level_bool.rs
+++ b/src/type_level_bool.rs
@@ -1,18 +1,18 @@
-#[derive(Copy, Clone, Debug)]
 pub struct True;
-#[derive(Copy, Clone, Debug)]
 pub struct False;
 
 pub trait ToBool {
     type Value;
     fn to_bool(_: Self) -> Self::Value;
 }
+
 impl ToBool for [(); 0] {
     type Value = False;
     fn to_bool(_: Self) -> Self::Value {
         False
     }
 }
+
 impl ToBool for [(); 1] {
     type Value = True;
     fn to_bool(_: Self) -> Self::Value {
@@ -21,9 +21,10 @@ impl ToBool for [(); 1] {
 }
 
 /// Converts a `const bool` to a type-level boolean.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! to_bool {
-    ($x:expr $(,)?) => {{
+    ($x:expr) => {{
         const ASSERT: bool = $x;
         $crate::type_level_bool::ToBool::to_bool([(); ASSERT as usize])
     }};

--- a/tests/trait_impl.rs
+++ b/tests/trait_impl.rs
@@ -6,8 +6,6 @@ extern crate static_assertions;
 
 use core::ops::Range;
 
-const_assert!(true);
-
 trait Tri<A: ?Sized, B: ?Sized, C: ?Sized> {}
 
 impl<T, A: ?Sized, B: ?Sized, C: ?Sized> Tri<A, B, C> for T {}

--- a/tests/trait_impl.rs
+++ b/tests/trait_impl.rs
@@ -6,6 +6,8 @@ extern crate static_assertions;
 
 use core::ops::Range;
 
+const_assert!(true);
+
 trait Tri<A: ?Sized, B: ?Sized, C: ?Sized> {}
 
 impl<T, A: ?Sized, B: ?Sized, C: ?Sized> Tri<A, B, C> for T {}


### PR DESCRIPTION
They now look like:
```
error[E0308]: mismatched types
  --> tests/trait_impl.rs:42:5
   |
42 |     const_assert!(false);
   |     ^^^^^^^^^^^^^^^^^^^^^ expected struct `static_assertions::True`, found struct `static_assertions::False`
   |
   = note: expected type `static_assertions::True`
              found type `static_assertions::False`
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

instead of
```
error[E0080]: evaluation of constant value failed
  --> tests/trait_impl.rs:40:1
   |
40 | const_assert!(false);
   | ^^^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
   |
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

This is purely cosmetic but I find it nice.