### PR TITLE
Select the 2018 language edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "static_assertions"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Nikolai Vazquez"]
+edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 homepage = "https://github.com/nvzqz/static-assertions-rs"


### PR DESCRIPTION
The use of the `?` macro operator, for zero-or-one selection, is only available
in the 2018 edition of the language. Without the `edition` key set in the
manifest, Rust compiles the crate in the 2015 syntax version, and rejects the
macros.

# Observation

`1.1.0` fails to compile on my machine, with the following error:

```text
error: expected `*` or `+`
  --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823\static_assertions-1.1.0/src/assert_cfg.rs:41:35
   |
41 |     ($($cfg:meta)+, $msg:expr $(,)?) => {
   |                                   ^
   |
   = note: `?` is not a macro repetition operator in the 2015 edition, but is accepted in the 2018 edition
```