### PR TITLE
Add assert_sizeof_eq!

### DIFF
--- a/src/assert_size.rs
+++ b/src/assert_size.rs
@@ -1,3 +1,30 @@
+/// Asserts a size of a type is equal to a literal usize.
+///
+/// # Examples
+///
+/// The size of [`u32`] is 4 in bytes on all platforms:
+///
+/// ```
+/// # #[macro_use] extern crate static_assertions;
+/// assert_sizeof_eq!(u32, 4);
+/// ```
+///
+/// The example fails to compile because size of [`u64`] is not 6 in bytes:
+///
+/// ```compile_fail
+/// # #[macro_use] extern crate static_assertions;
+/// assert_sizeof_eq!(u64, 6);
+/// ```
+#[macro_export]
+macro_rules! assert_sizeof_eq {
+    ($T:ty, $SIZE:literal) => {
+        const _: &str = match $crate::_core::mem::size_of::<$T>() {
+            $SIZE => "",
+            x => ["size of $T != $SIZE"][x],
+        };
+    };
+}
+
 /// Asserts that types are equal in size.
 ///
 /// When performing operations such as pointer casts or dealing with [`usize`]

--- a/tests/eq_size.rs
+++ b/tests/eq_size.rs
@@ -5,6 +5,7 @@
 extern crate static_assertions;
 
 assert_size_eq!(u8, u8, (u8,), [u8; 1]);
+assert_sizeof_eq!(u32, 4);
 
 mod assoc_type {
     trait Trait {


### PR DESCRIPTION
to equate size of a type to a literal usize at compile time.

I try to improve the error message with `std::concat!` but it doesn't help much:
Playground link for this newly added macro: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=3f807d04413a9706b8afc8472895f664