### PR TITLE
Fix copy/paste left-over in docs of `assert_obj_safe`

### DIFF
--- a/src/assert_obj_safe.rs
+++ b/src/assert_obj_safe.rs
@@ -36,14 +36,6 @@
 /// assert_obj_safe!(inner::BasicTrait);
 /// ```
 ///
-/// The following example fails to compile because raw pointers cannot be sent
-///  between threads safely:
-///
-/// ```compile_fail
-/// # #[macro_use] extern crate static_assertions; fn main() {}
-/// assert_impl!(*const u8, Send);
-/// ```
-///
 /// The following example fails to compile because generics without
 /// `where Self: Sized` are not allowed in [object-safe][object] trait methods:
 ///


### PR DESCRIPTION
It looks [the docs of `assert_obj_safe`](https://docs.rs/static_assertions/latest/static_assertions/macro.assert_obj_safe.html) contain a small "out of context" text fragment, perhaps a left-over from copy/pasting.